### PR TITLE
Remove tweet link from blog template

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,28 +2,11 @@
 layout: default
 ---
 
-<script
-  async
-  src="https://platform.twitter.com/widgets.js"
-  charset="utf-8"
-></script>
 {% assign author = site.data.authors[page.author] %}
 <div class="post-container">
   <div class="post-head">
     <a href="/blog.html" class="post-back-button">Back to all articles</a>
     <h1>{{ page.title }}</h1>
-    <div class="post-social">
-      <a
-        href="https://twitter.com/share?ref_src=twsrc%5Etfw"
-        class="twitter"
-        target="_blank"
-        ><img
-          src="/assets/images/twitter.svg"
-          alt="twitter logo"
-        />
-        <span>Tweet</span>
-      </a>
-    </div>
   </div>
   <div class="post-row">
     <div class="post-author">


### PR DESCRIPTION
1. I dont like it
2. It doesn’t appear to work
3. I dont think people use such links
4. It simplifies the template

Closes https://github.com/bitcoinbrink/website/issues/16