### PR TITLE
Add offset for section links to take fixed-height header into account

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -14,6 +14,13 @@
   font-display: swap;
 }
 
+:target::before {
+  content: "";
+  display: block;
+  height: 110px; /* fixed header height*/
+  margin: -110px 0 0; /* negative fixed header height */
+}
+
 $yellow: #feda09;
 $cream: #f1ede9;
 


### PR DESCRIPTION
We have a fixed header. Links to sections of pages hide the beginning of that section behind the header. Add an offset to fix that. See https://stackoverflow.com/a/28824157/933705

This is quick and dirty. The offset is correct for the desktop layout, but is a bit too much for the mobile layout, where the header is slightly shorter. It could be improved by being responsive to screen size.