### PR TITLE
Posts: add "What to expect when applying for a brink grant"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,11 @@ defaults:
     values:
       image: /assets/images/b_logo_whitebg.png
 
+  - scope:
+      path: _posts/
+    values:
+      permalink: /:year/:month/:day/:title
+
 # Build settings
 theme: minima
 plugins:

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -1,0 +1,4 @@
+{% comment %}<!-- frequently used URLs, especially ones we might want to change globally one day -->{% endcomment %}
+[brink board]: /#board
+[brink grant application]: https://brink.homerun.co/grants
+[brink sponsors]: /sponsors

--- a/_posts/2021-08-05-grant-process.md
+++ b/_posts/2021-08-05-grant-process.md
@@ -1,0 +1,95 @@
+---
+title: What To Expect When Applying For A Brink Grant
+layout: post
+author: brink
+name: "brink"
+alt: &summary An overview of the process of applying for a Brink grant—and what happens after.
+category: "News"
+description: *summary
+---
+Thanks to the support of our [sponsors][brink sponsors], Brink has awarded [three full
+time grants][grants1] and [two partial grants][grants2] in the past four
+months.  In this post, we describe how we designed our grant program to
+maximize the time developers spend working on Bitcoin and to minimize the
+time they spend worrying about finding funding.
+
+## The application
+
+Our grant [application][brink grant application] currently contains only
+three questions requiring a detailed response:
+
+1. Describe your prior contributions to Bitcoin-related projects.
+
+2. What will you work on during your grant and what deliverables do you
+   expect to produce?
+
+3. Is there anything else we need to know?
+
+For any applicant with a history of open source contributions and who
+already knows what they want to work on, we expect that a high-quality
+application can be written in less than an hour.
+
+## The interview
+
+If an application looks promising, a video call is scheduled between the
+applicant and one or two members of the grant committee, which currently
+consists of Brink's five [board members][brink board].  Members include
+experienced contributors to Bitcoin Core and LND, so we're often able to
+match the applicant with a well-informed interviewer.
+
+Although the interview necessarily includes some formalities, it's also
+a chance for the applicant to talk about the parts of Bitcoin technology
+that excite them the most.  We enjoy the conversations and hope that
+applicants do as well.
+
+## The offer
+
+The grant committee meets every two to three months and evaluates all
+qualified proposals based on how much we expect the deliverables will
+benefit Bitcoin users, factoring in the applicant's history of
+completing projects with similar scope.  After the meeting, each
+applicant is sent an email either declining or accepting their proposal.
+Successful applicants receive an offer for either a full-time or
+part-time grant.  Part-time grant offers are tailored to the applicant's
+specific circumstances.  For most other grants, our standard offer has
+two key features:
+
+1. **Personalized compensation:** every applicant has a different level
+   of experience, a different history of contribution, and a proposal
+   with a different degree of expected impact.  Offering every applicant
+   the same amount would almost guarantee that the best contributors we
+   could find would be undercompensated.  Instead, the grant committee
+   uses its members' experience in software development in general, and
+   Bitcoin and LN specifically, to make each applicant a compensation
+   offer unique to their situation.
+
+2. **Full time and exclusive:** our full-time grant contract forbids
+   grantees from seeking additional money from other sponsors for the
+   duration of the grant.  We want to make sure grantees are working
+   full time on the projects described in their proposals, not trying to
+   scrape together a full-time salary by applying for a succession of
+   part-time grants.  Requiring exclusivity ensures that we're motivated
+   to offer applicants fair compensation---and that applicants are
+   motivated to only accept an offer they find entirely satisfactory.
+
+    Of course, grantees are still free to accept spontaneous donations
+    from the community and to work on side projects in their free time
+    (including lightly compensated work such as speaking engagements or
+    article writing).  Exclusivity means grantees shouldn't *need*
+    secondary donations or side projects and that their primary focus
+    should be on delivering the proposed project.  It doesn't mean that
+    grantees must deny themselves the perks and career opportunities
+    that come from working on problems that the wider community finds
+    both interesting and important.
+
+If the applicant accepts our offer, we typically complete the contract
+and send the first quarterly grant payment to them in less than a week.
+
+We hope this post has adequately explained how our grant program works
+to get independent Bitcoin developers the funding they deserve without
+unnecessary complications or delays.  If that interests you, we'd love
+to receive your [application][brink grant application].
+
+{% include references.md %}
+[grants1]: /blog/2021/03/31/grantees/
+[grants2]: /blog/2021/07/15/grantees/


### PR DESCRIPTION
Adds the blog post mentioned in the PR title.

Also adds a default permalink template, which means that the post date (and name) can be updated by simply `mv`ing the file, instead of changing things in two places.  This only applies to posts without an explicit permalink set, which is currently only this newly-added post:

    $ cd _posts
    $ grep -rL ^permalink
    2021-07-20-grant-process.md